### PR TITLE
Better error handling

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -38,11 +38,11 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2021-10-21.
+This package was submitted to CRAN on 2023-02-05.
 Once it is accepted, delete this file and tag the release (commit ac6e356).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RedditExtractoR
 Type: Package
 Title: Reddit Data Extraction Toolkit
-Version: 3.0.6
+Version: 3.0.7
 Imports:
     RJSONIO,
     utils,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # RedditExtractor
 
+## Version 3.0.7
+
+`get_thread_content` can now handle errors without interrupting parsing
+
 ## Version 3.0.6
 
 Added timestamps to extracted comments and threads

--- a/R/json_extractors.R
+++ b/R/json_extractors.R
@@ -28,7 +28,7 @@ get_replies_or_null <- function(element) {
 
 
 # Get the children component from JSON
-get_children <- function(json) json[[2]]$children
+get_children <- function(json) if(length(json)) json[[2]]$children else NULL
 
 
 # Extract thread content out of a json structure

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -22,6 +22,7 @@ parse_request_url <- function(request_url, data_builder, after = NA, data_list =
 
 parse_thread_url <- function(request_url){
   json <- url_to_json(request_url %+% ".json?limit=500")
+  if(!length(json)) return(list(thread=list()))
   comments_exist <- length(get_comment_json(json)) > 0
   list(
     thread = json |>

--- a/R/url_to_json.R
+++ b/R/url_to_json.R
@@ -4,4 +4,7 @@ url_to_json <- function(url) url |>
   utils::URLencode() |>
   readLines(warn = FALSE) |>
   RJSONIO::fromJSON() |>
-  tryCatch(error = function(e) stop("Cannot read from Reddit, check your inputs or internet connection"))
+  tryCatch(error = function(e) {
+    warning(e)
+    return(list())
+  })


### PR DESCRIPTION
# Better error handling
  
Description: some threads are marked as forbidden and they can stop the entire URL parsing process. This PR allows us to throw warnings but allows the rest of the threads to pass.

Closes #34 
  
- [x] Tested locally on Reddit data
- [x] Updated version
- [x] Updated docs
- [x] Updated NEWS.md
- [x] Updated cran-comments.md
  
